### PR TITLE
fix unused variable in stats_set_str macro

### DIFF
--- a/src/cm_stats_api.h
+++ b/src/cm_stats_api.h
@@ -182,7 +182,7 @@ bool
 
 #define stats_set_str(h, v) do { \
   char *vp = (char *)v; \
-  stats_set(h, STATS_TYPE_STRING, v); \
+  stats_set(h, STATS_TYPE_STRING, vp); \
 } while(0)
 
 /* Specific to histograms, set with a count.


### PR DESCRIPTION
currently breaks when included by someone using `-Werror`, this fix changes it to match the other `stats_set_*` macros.