### PR TITLE
README review

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ numeric (various native C integer types and doubles), and log-linear histograms
 via the [circllhist](https://github.com/circonus-labs/libcircllhist)
 implementation.
 
-Metric names are exposed both hierarchically as is common in legacy systems
-(e.g. `acme.users.login.count`) and "Metrics 2.0"-style tagged metrics (.e.g.,
+Metric names are exposed both hierarchically, as is common in legacy systems
+(e.g. `acme.users.login.count`), and "Metrics 2.0"-style tagged metrics (.e.g.,
 `count{app=acme,subsystem=users,operation=login}`).  Tags are exposed in
 Circonus' preferred format:
 `count|ST[app:acme,operation:login,subsystem:users]`.
@@ -50,14 +50,15 @@ apins = stats_register_ns(rec, app, "api");
 stats_ns_add_tag(apins, "subsystem", "api");
 ```
 
-This has created a heirarchy of `mycoolapp.api`. The `stats_ns_add_tag` call
+This has created a hierarchy of `mycoolapp.api`. The `stats_ns_add_tag` call
 will attach a tag `app:mycoolapp` to that branch (and thus all children) of the
 metrics tree. Likewise, any metrics registered under the `api` namespace will
 have both the `app:mycoolapp` tag as well as the `subsystem:api` tag.
 
-Now we will put three metrics under this: 1) a version for our application
-under the `mycoolapp` namespace, 2) a count of API calls under the `api`
-namespace, and 3) a histogram of latencies.
+Now we will put three metrics under this:
+ 1. A version for our application under the `mycoolapp` namespace.
+ 1. A count of API calls under the `api` namespace.
+ 1. A histogram of latencies.
 
 Additionally we will inform the library what the tagged variant of each of
 these metrics is.
@@ -68,8 +69,8 @@ stats_handle_t *version_handle = stats_register(appns, "version", STATS_TYPE_STR
 stats_observe(version_handle, STATS_TYPE_STRING, &version_string);
 ```
 This will create a metric `mycoolapp.version` that observes the
-`version_string` symbol and will report it's value (even if it changes).  The
-fully qualified, tagged variant of this metric is `version|ST[app:mycoolapp]`.
+`version_string` symbol and reports its value (even if it changes).  The fully
+qualified, tagged variant of this metric is `version|ST[app:mycoolapp]`.
 
 ```c
 stats_handle_t *api_req_counter;

--- a/README.md
+++ b/README.md
@@ -6,15 +6,26 @@ datatypes, and being high-performance, contention-avoiding, thread-safe.
 
 ## High Level
 
-The library supports exposing name values where those values are textual, numeric (various native C integer types and doubles), and log-linear histograms via the circllhist implementation.
+The library supports exposing name values where those values are textual,
+numeric (various native C integer types and doubles), and log-linear histograms
+via the circllhist implementation.
 
-Metric names are exposed both heirarchically as is common in legacy systems (e.g. `acme.users.login.count`) and "Metrics 2.0"-style tagged metrics (.e.g. `count{app=acme,subsystem=users,operation=login}`).  Tags are exposed in Circonus' preferred format: `count|ST[app:acme,operation:login,subsystem:users]`.
+Metric names are exposed both heirarchically as is common in legacy systems
+(e.g. `acme.users.login.count`) and "Metrics 2.0"-style tagged metrics (.e.g.
+`count{app=acme,subsystem=users,operation=login}`).  Tags are exposed in
+Circonus' preferred format:
+`count|ST[app:acme,operation:login,subsystem:users]`.
 
-It is highly recommended that programmers attach units in a standard way via a `units` tag using [standard set of units](units.md).
+It is highly recommended that programmers attach units in a standard way via a
+`units` tag using [standard set of units](units.md).
 
-> Circonus supports multi-value tags, so a metric can be tagged with `team:a` and `team:b` simultaneously.  If your monitoring system is incapable of handling this type of tagging, be mindful.
+> Circonus supports multi-value tags, so a metric can be tagged with `team:a`
+> and `team:b` simultaneously.  If your monitoring system is incapable of
+> handling this type of tagging, be mindful.
 
-Aside from nomenclature and metric name formatting, there is no reliance on the Circonus platform whatsoever.  The library is standalone and makes it easy to track metrics and expose them over JSON.
+Aside from nomenclature and metric name formatting, there is no reliance on the
+Circonus platform whatsoever.  The library is standalone and makes it easy to
+track metrics and expose them over JSON.
 
 ## Usage
 
@@ -26,7 +37,8 @@ stats_recorder_t *rec;
 rec = stats_recorder_alloc(); 
 ```
 
-Next we create a namespace.  A namespace is part of the metric's heirarchical name.
+Next we create a namespace.  A namespace is part of the metric's heirarchical
+name.
 
 ```c
 stats_ns_t *root, *appns, *apins;
@@ -37,18 +49,26 @@ apins = stats_register_ns(rec, app, "api");
 stats_ns_add_tag(apins, "subsystem", "api");
 ```
 
-This has created a heirarchy of `mycoolapp.api`. The `stats_ns_add_tag` call will attach a tag `app:mycoolapp` to that branch (and thus all children) of the metrics tree. Likewise, any metrics registered under the api namespace will have both the `app:mycoolapp` tag as well as the `subsytem:api` tag.
+This has created a heirarchy of `mycoolapp.api`. The `stats_ns_add_tag` call
+will attach a tag `app:mycoolapp` to that branch (and thus all children) of the
+metrics tree. Likewise, any metrics registered under the api namespace will
+have both the `app:mycoolapp` tag as well as the `subsytem:api` tag.
 
-Now we will put three metrics under this: 1) a version for our application under the application namespace, 2) a count of API calls under the api namespace, and 3) a histogram of latencies.
+Now we will put three metrics under this: 1) a version for our application
+under the application namespace, 2) a count of API calls under the api
+namespace, and 3) a histogram of latencies.
 
-Additionally we will inform the library what the tagged variant of each of these metrics is.
+Additionally we will inform the library what the tagged variant of each of
+these metrics is.
 
 ```c
 const char *version_string = "v1.9.2";
 stats_handle_t *version_handle = stats_register(appns, "version", STATS_TYPE_STRING);
 stats_observe(version_handle, STATS_TYPE_STRING, &version_string);
 ```
-This will create a metric `mycoolapp.version` that observes the `version_string` symbol and will report it's value (even if it changes).  The fully qualified tagged variant of this metric is `version|ST[app:mycoolapp]`.
+This will create a metric `mycoolapp.version` that observes the
+`version_string` symbol and will report it's value (even if it changes).  The
+fully qualified tagged variant of this metric is `version|ST[app:mycoolapp]`.
 
 ```c
 stats_handle_t *api_req_counter;
@@ -61,7 +81,11 @@ stats_handle_add_tag(api_req_counter, "units", STATS_UNITS_REQUESTS);
 stats_add64(api_req_counter, 1);
 ```
 
-This will expose a `api_req_counter` handle to the application on which is can "count" things using the `stats_add32` or `stats_add64` functions.  These functions are design to reduce multi-threaded contention and are lock-free.  This metric is called `mycoolapp.api.calls` or in tagged form `calls|ST[app:mycoolapp,subsystem:api,units:requests]`.
+This will expose a `api_req_counter` handle to the application on which is can
+"count" things using the `stats_add32` or `stats_add64` functions.  These
+functions are design to reduce multi-threaded contention and are lock-free.
+This metric is called `mycoolapp.api.calls` or in tagged form
+`calls|ST[app:mycoolapp,subsystem:api,units:requests]`.
 
 ```c
 stats_handle_t *api_latency;
@@ -76,13 +100,23 @@ uint64_t start_ns = get_nanos();
 stats_set_hist_instscale(api_latency, get_nanos() - start_ns, -9, 1);
 ```
 
-This will track the latency of every API call into a histogram called `mycoolapp.api.latency` or in tagged for `latency|ST[app:mycoolapp,subsystem:api,units:seconds]`.  The "intscale" variant of histogram insertion allows us to insert nanoseconds into a metric tracking seconds by specifying that it should be scaled by 10^-9.
+This will track the latency of every API call into a histogram called
+`mycoolapp.api.latency` or in tagged for
+`latency|ST[app:mycoolapp,subsystem:api,units:seconds]`.  The "intscale"
+variant of histogram insertion allows us to insert nanoseconds into a metric
+tracking seconds by specifying that it should be scaled by 10^-9.
 
 ## Extraction
 
-As a standalone library, libcircmetrics provides a functional writer mechanism to produce a JSON document with all the data in it.
+As a standalone library, libcircmetrics provides a functional writer mechanism
+to produce a JSON document with all the data in it.
 
-The "simple" format is `{ "key": value }` in JSON.  However, due to JSON's horribly poor specification around numbers, it is often useful to know what type the measurement is, so the "not simple" format is: `{ "key": { "_type": "T", "_value": "V" }}` where T is `s` for strings, `i`, `I`, `l`, `L`, or `n` for `int32_t`, `uint32_t`, `int64_t`, `uint64_t`, or `double`, respectively, or `H` for histograms.
+The "simple" format is `{ "key": value }` in JSON.  However, due to JSON's
+horribly poor specification around numbers, it is often useful to know what
+type the measurement is, so the "not simple" format is: `{ "key": { "_type":
+"T", "_value": "V" }}` where T is `s` for strings, `i`, `I`, `l`, `L`, or `n`
+for `int32_t`, `uint32_t`, `int64_t`, `uint64_t`, or `double`, respectively, or
+`H` for histograms.
 
 ```c
 static ssize_t write_to_fd(void *closure, const char *buf, size_t len) {

--- a/units.md
+++ b/units.md
@@ -5,7 +5,7 @@
 1. meters (m) length
 1. grams (g) mass
 1. seconds (s) time
-1. amperes (A) electrct current
+1. amperes (A) electrical current
 1. kelvin (K) thermodynamic temperature
 1. moles (mol) amount of substance
 1. candela (cd) luminous intensity

--- a/units.md
+++ b/units.md
@@ -5,7 +5,7 @@
 1. meters (m) length
 1. grams (g) mass
 1. seconds (s) time
-1. amperes (A) electrical current
+1. amperes (A) electric current
 1. kelvin (K) thermodynamic temperature
 1. moles (mol) amount of substance
 1. candela (cd) luminous intensity


### PR DESCRIPTION
Break up long lines for easier maintenance.

Grammatical nits.

Use an ordered list for metrics in the creation example.

Fix a typo on the units page.